### PR TITLE
feat: auto window close

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@ nnoremap <C-w>j <Cmd>call jumpout#select_jump('j', ['bo term', 'Trouble workspac
 ## Todo
 
 - [x] docs
-- [ ] autocmd for closing of windows opend by jumpout
+- [x] autocmd for closing of windows opend by jumpout
 - [ ] loop option

--- a/autoload/jumpout.vim
+++ b/autoload/jumpout.vim
@@ -6,10 +6,12 @@
 function! jumpout#jump(direction, cmd) abort
   if (!jumpout_utils#_check_jumpable(a:direction)) " false = run cmd
     execute a:cmd
+    execute(printf('wincmd %s', a:direction))
+    execute(printf('map <buffer> <C-w>%s <Cmd>close<CR>', jumpout_utils#_reverse_direction(a:direction)))
+  else
+    " fallback <C-w>direction or jump into opened window
+    execute(printf('wincmd %s', a:direction))
   endif
-
-  " fallback <C-w>direction or jump into opened window
-  execute(printf('wincmd %s', a:direction))
 endfunction
 
 " selectable jump commands.

--- a/autoload/jumpout_utils.vim
+++ b/autoload/jumpout_utils.vim
@@ -8,6 +8,18 @@ function! jumpout_utils#_check_jumpable(direction) abort
   return winnr() != winnr(a:direction)
 endfunction
 
+function! jumpout_utils#_reverse_direction(direction) abort
+  if a:direction ==# 'h'
+    return 'l'
+  elseif a:direction ==# 'j'
+    return 'k'
+  elseif a:direction ==# 'k'
+    return 'j'
+  elseif a:direction ==# 'l'
+    return 'h'
+  endif
+endfunction
+
 " https://zenn.dev/kawarimidoll/articles/97331bd750aec8 thanks!
 " vim.ui.select like menu
 function! jumpout_utils#_select(items, opts, on_choice) abort


### PR DESCRIPTION
- jumpout起因で開いたウィンドウはフォーカスが外れたときに`close`により隠れるようにした autocmd使うまでもなかった．
https://github.com/Allianaab2m/jumpout.vim/blob/75218b0a668961a5f23919fc69ecf2d020be6e25/autoload/jumpout.vim#L10

- それ以外の画面分割(普通に`vsplit`したときとか)は関係ないようになってる